### PR TITLE
 fix empty reply from server error

### DIFF
--- a/libraries/ESPmDNS/examples/mDNS_Web_Server/mDNS_Web_Server.ino
+++ b/libraries/ESPmDNS/examples/mDNS_Web_Server/mDNS_Web_Server.ino
@@ -96,7 +96,6 @@ void loop(void)
     req = req.substring(addr_start + 1, addr_end);
     Serial.print("Request: ");
     Serial.println(req);
-    client.flush();
 
     String s;
     if (req == "/")
@@ -115,6 +114,7 @@ void loop(void)
     }
     client.print(s);
 
+    client.stop();
     Serial.println("Done with client");
 }
 


### PR DESCRIPTION
The flush causes an empty response a client side.

see https://github.com/espressif/arduino-esp32/issues/2902